### PR TITLE
Prints the title of a task before executing the task

### DIFF
--- a/src/LaravelConsoleTaskServiceProvider.php
+++ b/src/LaravelConsoleTaskServiceProvider.php
@@ -40,11 +40,25 @@ class LaravelConsoleTaskServiceProvider extends ServiceProvider
         Command::macro(
             'task',
             function (string $title, callable $task) {
-                $this->output->write("$title: ");
+                $this->output->write("$title: <comment>loading...</comment>");
 
-                return tap($task() === false ? false : true, function ($result) {
-                    $this->output->writeln($result ? '<info>✔</info>' : '<error>failed</error>');
-                });
+                $result = $task() === false ? false : true;
+
+                if ($this->output->isDecorated()) { // Determines if we can use escape sequences
+                    // Move the cursor to the beginning of the line
+                    $this->output->write("\x0D");
+
+                    // Erase the line
+                    $this->output->write("\x1B[2K");
+                } else {
+                    $this->output->writeln(''); // Make sure we first close the previous line
+                }
+
+                $this->output->writeln(
+                    "$title: ".($result ? '<info>✔</info>' : '<error>failed</error>')
+                );
+
+                return $result;
             }
         );
     }

--- a/src/LaravelConsoleTaskServiceProvider.php
+++ b/src/LaravelConsoleTaskServiceProvider.php
@@ -40,10 +40,10 @@ class LaravelConsoleTaskServiceProvider extends ServiceProvider
         Command::macro(
             'task',
             function (string $title, callable $task) {
-                return tap($task() === false ? false : true, function ($result) use ($title) {
-                    $this->output->writeln(
-                        "$title: ".($result ? '<info>✔</info>' : '<error>failed</error>')
-                    );
+                $this->output->write("$title: ");
+
+                return tap($task() === false ? false : true, function ($result) {
+                    $this->output->writeln($result ? '<info>✔</info>' : '<error>failed</error>');
                 });
             }
         );

--- a/tests/LaravelConsoleTaskTest.php
+++ b/tests/LaravelConsoleTaskTest.php
@@ -26,19 +26,44 @@ use NunoMaduro\LaravelConsoleTask\LaravelConsoleTaskServiceProvider;
  */
 class LaravelConsoleTaskTest extends TestCase
 {
-    public function testSuccessfulTask()
+    public function testSuccessfulTaskWithReturnValueAndDecoratedOutput()
+    {
+        $this->performTestSuccessfulTaskWithDecoratedOutput(
+            function () {
+                return true;
+            }
+        );
+    }
+
+    public function testSuccessfulTaskWithoutReturnValueAndDecoratedOutput()
+    {
+        $this->performTestSuccessfulTaskWithDecoratedOutput(
+            function () {
+            }
+        );
+    }
+
+    private function performTestSuccessfulTaskWithDecoratedOutput(callable $task)
     {
         $command = new Command();
 
         $outputMock = $this->createMock(OutputInterface::class);
 
-        $outputMock->expects($this->exactly(2))
-            ->method('write')
-            ->with('Foo: ');
+        $outputMock->expects($this->once())
+            ->method('isDecorated')
+            ->willReturn(true);
 
-        $outputMock->expects($this->exactly(2))
+        $outputMock->expects($this->exactly(3))
+            ->method('write')
+            ->withConsecutive(
+                [$this->equalTo('Foo: <comment>loading...</comment>')],
+                [$this->equalTo("\x0D")],
+                [$this->equalTo("\x1B[2K")]
+            );
+
+        $outputMock->expects($this->once())
             ->method('writeln')
-            ->with('<info>✔</info>');
+            ->with('Foo: <info>✔</info>');
 
         $commandReflection = new ReflectionClass($command);
 
@@ -49,36 +74,121 @@ class LaravelConsoleTaskTest extends TestCase
         (new LaravelConsoleTaskServiceProvider(null))->boot();
 
         $this->assertTrue(
-            $command->task(
-                'Foo',
-                function () {
-                    return true;
-                }
-            )
-        );
-
-        $this->assertTrue(
-            $command->task(
-                'Foo',
-                function () {
-                }
-            )
+            $command->task('Foo', $task)
         );
     }
 
-    public function testUnsuccessfulTask()
+    public function testSuccessfulTaskWithReturnValueAndWithoutDecoratedOutput()
+    {
+        $this->performTestSuccessfulTaskWithoutDecoratedOutput(
+            function () {
+                return true;
+            }
+        );
+    }
+
+    public function testSuccessfulTaskWithoutReturnValueAndWithoutDecoratedOutput()
+    {
+        $this->performTestSuccessfulTaskWithoutDecoratedOutput(
+            function () {
+            }
+        );
+    }
+
+    private function performTestSuccessfulTaskWithoutDecoratedOutput(callable $task)
     {
         $command = new Command();
 
         $outputMock = $this->createMock(OutputInterface::class);
 
         $outputMock->expects($this->once())
+            ->method('isDecorated')
+            ->willReturn(false);
+
+        $outputMock->expects($this->once())
             ->method('write')
-            ->with('Bar: ');
+            ->with('Foo: <comment>loading...</comment>');
+
+        $outputMock->expects($this->exactly(2))
+            ->method('writeln')
+            ->withConsecutive(
+                [''],
+                ['Foo: <info>✔</info>']
+            );
+
+        $commandReflection = new ReflectionClass($command);
+
+        $commandOutputProperty = $commandReflection->getProperty('output');
+        $commandOutputProperty->setAccessible(true);
+        $commandOutputProperty->setValue($command, $outputMock);
+
+        (new LaravelConsoleTaskServiceProvider(null))->boot();
+
+        $this->assertTrue(
+            $command->task('Foo', $task)
+        );
+    }
+
+    public function testUnsuccessfulTaskWithDecoratedOutput()
+    {
+        $command = new Command();
+
+        $outputMock = $this->createMock(OutputInterface::class);
+
+        $outputMock->expects($this->once())
+            ->method('isDecorated')
+            ->willReturn(true);
+
+        $outputMock->expects($this->exactly(3))
+            ->method('write')
+            ->withConsecutive(
+                [$this->equalTo('Bar: <comment>loading...</comment>')],
+                [$this->equalTo("\x0D")],
+                [$this->equalTo("\x1B[2K")]
+            );
 
         $outputMock->expects($this->once())
             ->method('writeln')
-            ->with('<error>failed</error>');
+            ->with('Bar: <error>failed</error>');
+
+        $commandReflection = new ReflectionClass($command);
+
+        $commandOutputProperty = $commandReflection->getProperty('output');
+        $commandOutputProperty->setAccessible(true);
+        $commandOutputProperty->setValue($command, $outputMock);
+
+        (new LaravelConsoleTaskServiceProvider(null))->boot();
+
+        $this->assertFalse(
+            $command->task(
+                'Bar',
+                function () {
+                    return false;
+                }
+            )
+        );
+    }
+
+    public function testUnsuccessfulTaskWithoutDecoratedOutput()
+    {
+        $command = new Command();
+
+        $outputMock = $this->createMock(OutputInterface::class);
+
+        $outputMock->expects($this->once())
+            ->method('isDecorated')
+            ->willReturn(false);
+
+        $outputMock->expects($this->once())
+            ->method('write')
+            ->with('Bar: <comment>loading...</comment>');
+
+        $outputMock->expects($this->exactly(2))
+            ->method('writeln')
+            ->withConsecutive(
+                [''],
+                ['Bar: <error>failed</error>']
+            );
 
         $commandReflection = new ReflectionClass($command);
 

--- a/tests/LaravelConsoleTaskTest.php
+++ b/tests/LaravelConsoleTaskTest.php
@@ -33,8 +33,12 @@ class LaravelConsoleTaskTest extends TestCase
         $outputMock = $this->createMock(OutputInterface::class);
 
         $outputMock->expects($this->exactly(2))
+            ->method('write')
+            ->with('Foo: ');
+
+        $outputMock->expects($this->exactly(2))
             ->method('writeln')
-            ->with('Foo: <info>✔</info>');
+            ->with('<info>✔</info>');
 
         $commandReflection = new ReflectionClass($command);
 
@@ -69,8 +73,12 @@ class LaravelConsoleTaskTest extends TestCase
         $outputMock = $this->createMock(OutputInterface::class);
 
         $outputMock->expects($this->once())
+            ->method('write')
+            ->with('Bar: ');
+
+        $outputMock->expects($this->once())
             ->method('writeln')
-            ->with('Bar: <error>failed</error>');
+            ->with('<error>failed</error>');
 
         $commandReflection = new ReflectionClass($command);
 


### PR DESCRIPTION
This PR changes the way tasks are written to the console. It does not have any impact on style, content or formatting - just on the time, when something is printed.

### Before

The task handed to `$this->task($title, $task)` was executed, after which a line was printed with the `$title` and the result of the `$task` function.

### After

The title handed to `$this->task($title, $task)` is now written to the output before the task is executed. As soon as a result of the task is available, it will be attached to the output on the same line. The output format has not changed.

### Reasons

For long running tasks, it is quite inconvenient to not know what is going on. With this change, the user will see what task is being executed and that it has not finished yet (indicated by a missing result and, depending on the console, a blinking cursor).

### Additional information

I had to change the test cases slightly to match the new function calls of the macro.