### PR TITLE
Allow to customize loading text

### DIFF
--- a/src/LaravelConsoleTaskServiceProvider.php
+++ b/src/LaravelConsoleTaskServiceProvider.php
@@ -39,8 +39,8 @@ class LaravelConsoleTaskServiceProvider extends ServiceProvider
          */
         Command::macro(
             'task',
-            function (string $title, $task = null) {
-                $this->output->write("$title: <comment>loading...</comment>");
+            function (string $title, $task = null, $loadingText = 'loading...') {
+                $this->output->write("$title: <comment>{$loadingText}</comment>");
 
                 if ($task === null) {
                     $result = true;


### PR DESCRIPTION
`loading...` is not always the most appropriate verb for a task that is running. Depending on the context, a command might be `generating` something, `connecting` to some remote server, `downloading` a file, etc.

So I thought it could be nice to be able to customize this hardcoded string.

To avoid any breaking change, this pull request simply adds an argument at the end of the method signature, which gives us the following usage:
```php
$this->task('Foo', $callable, 'uploading...');
```