### PR TITLE
handle thrown exceptions in a task

### DIFF
--- a/src/LaravelConsoleTaskServiceProvider.php
+++ b/src/LaravelConsoleTaskServiceProvider.php
@@ -65,7 +65,7 @@ class LaravelConsoleTaskServiceProvider extends ServiceProvider
                 $this->output->writeln(
                     "$title: ".($result ? '<info>✔</info>' : '<error>failed</error>')
                 );
-                
+
                 if (isset($taskException)) {
                     throw $taskException;
                 }

--- a/src/LaravelConsoleTaskServiceProvider.php
+++ b/src/LaravelConsoleTaskServiceProvider.php
@@ -45,7 +45,11 @@ class LaravelConsoleTaskServiceProvider extends ServiceProvider
                 if ($task === null) {
                     $result = true;
                 } else {
-                    $result = $task() === false ? false : true;
+                    try {
+                        $result = $task() === false ? false : true;
+                    } catch (\Exception $taskException) {
+                        $result = false;
+                    }
                 }
 
                 if ($this->output->isDecorated()) { // Determines if we can use escape sequences
@@ -61,6 +65,10 @@ class LaravelConsoleTaskServiceProvider extends ServiceProvider
                 $this->output->writeln(
                     "$title: ".($result ? '<info>✔</info>' : '<error>failed</error>')
                 );
+                
+                if (isset($taskException)) {
+                    throw $taskException;
+                }
 
                 return $result;
             }

--- a/tests/LaravelConsoleTaskTest.php
+++ b/tests/LaravelConsoleTaskTest.php
@@ -237,7 +237,7 @@ class LaravelConsoleTaskTest extends TestCase
 
         (new LaravelConsoleTaskServiceProvider(null))->boot();
 
-        $this->expectException(\Exception::class);  
+        $this->expectException(\Exception::class);
 
         $command->task(
             'Bar',

--- a/tests/LaravelConsoleTaskTest.php
+++ b/tests/LaravelConsoleTaskTest.php
@@ -245,6 +245,5 @@ class LaravelConsoleTaskTest extends TestCase
                 throw new \Exception();
             }
         );
-
     }
 }

--- a/tests/LaravelConsoleTaskTest.php
+++ b/tests/LaravelConsoleTaskTest.php
@@ -207,4 +207,44 @@ class LaravelConsoleTaskTest extends TestCase
             )
         );
     }
+
+    public function testUnsuccessfulTaskWithException()
+    {
+        $command = new Command();
+
+        $outputMock = $this->createMock(OutputInterface::class);
+
+        $outputMock->expects($this->once())
+            ->method('isDecorated')
+            ->willReturn(false);
+
+        $outputMock->expects($this->once())
+            ->method('write')
+            ->with('Bar: <comment>loading...</comment>');
+
+        $outputMock->expects($this->exactly(2))
+            ->method('writeln')
+            ->withConsecutive(
+                [''],
+                ['Bar: <error>failed</error>']
+            );
+
+        $commandReflection = new ReflectionClass($command);
+
+        $commandOutputProperty = $commandReflection->getProperty('output');
+        $commandOutputProperty->setAccessible(true);
+        $commandOutputProperty->setValue($command, $outputMock);
+
+        (new LaravelConsoleTaskServiceProvider(null))->boot();
+
+        $this->expectException(\Exception::class);  
+
+        $command->task(
+            'Bar',
+            function () {
+                throw new \Exception();
+            }
+        );
+
+    }
 }


### PR DESCRIPTION
At the moment, if an exception is thrown in a task, the task remains in "loading...".

This PR catch any exceptions in task callback, and throw back the exception after considering the task as failed.