### PR TITLE
adds ability to customize error message and fixes to docblocks on tas…

### DIFF
--- a/src/LaravelConsoleTaskServiceProvider.php
+++ b/src/LaravelConsoleTaskServiceProvider.php
@@ -34,12 +34,14 @@ class LaravelConsoleTaskServiceProvider extends ServiceProvider
          *
          * @param  string $title
          * @param  callable|null $task
+         * @param  string $errorMessage
+         * @param  string $loadingText
          *
          * @return bool With the result of the task.
          */
         Command::macro(
             'task',
-            function (string $title, $task = null, $loadingText = 'loading...') {
+            function (string $title, $task = null, string $errorMessage = "failed", string $loadingText = 'loading...') {
                 $this->output->write("$title: <comment>{$loadingText}</comment>");
 
                 if ($task === null) {
@@ -63,7 +65,7 @@ class LaravelConsoleTaskServiceProvider extends ServiceProvider
                 }
 
                 $this->output->writeln(
-                    "$title: ".($result ? '<info>✔</info>' : '<error>failed</error>')
+                    "$title: ".($result ? '<info>✔</info>' : "<error>{$errorMessage}</error>")
                 );
 
                 if (isset($taskException)) {

--- a/src/LaravelConsoleTaskServiceProvider.php
+++ b/src/LaravelConsoleTaskServiceProvider.php
@@ -34,14 +34,14 @@ class LaravelConsoleTaskServiceProvider extends ServiceProvider
          *
          * @param  string $title
          * @param  callable|null $task
-         * @param  string $errorMessage
          * @param  string $loadingText
+         * @param  string $errorMessage
          *
          * @return bool With the result of the task.
          */
         Command::macro(
             'task',
-            function (string $title, $task = null, string $errorMessage = "failed", string $loadingText = 'loading...') {
+            function (string $title, $task = null, string $loadingText = 'loading...', string $errorMessage = 'failed') {
                 $this->output->write("$title: <comment>{$loadingText}</comment>");
 
                 if ($task === null) {

--- a/tests/LaravelConsoleTaskTest.php
+++ b/tests/LaravelConsoleTaskTest.php
@@ -26,6 +26,17 @@ use NunoMaduro\LaravelConsoleTask\LaravelConsoleTaskServiceProvider;
  */
 class LaravelConsoleTaskTest extends TestCase
 {
+    /**
+     * Custom task error message
+     * @var string
+     */
+    protected $customErrorMessage = 'something went wrong';
+    /**
+     * Custom task loading message
+     * @var string
+     */
+    protected $customLoadingMessage = 'doing stuff...';
+
     public function testSuccessfulTaskWithReturnValueAndDecoratedOutput()
     {
         $this->performTestSuccessfulTaskWithDecoratedOutput(
@@ -56,7 +67,7 @@ class LaravelConsoleTaskTest extends TestCase
         $outputMock->expects($this->exactly(3))
             ->method('write')
             ->withConsecutive(
-                [$this->equalTo('Foo: <comment>loading...</comment>')],
+                [$this->equalTo("Foo: <comment>{$this->customLoadingMessage}</comment>")],
                 [$this->equalTo("\x0D")],
                 [$this->equalTo("\x1B[2K")]
             );
@@ -74,7 +85,7 @@ class LaravelConsoleTaskTest extends TestCase
         (new LaravelConsoleTaskServiceProvider(null))->boot();
 
         $this->assertTrue(
-            $command->task('Foo', $task)
+            $command->task('Foo', $task, $this->customLoadingMessage)
         );
     }
 
@@ -107,7 +118,7 @@ class LaravelConsoleTaskTest extends TestCase
 
         $outputMock->expects($this->once())
             ->method('write')
-            ->with('Foo: <comment>loading...</comment>');
+            ->with("Foo: <comment>{$this->customLoadingMessage}</comment>");
 
         $outputMock->expects($this->exactly(2))
             ->method('writeln')
@@ -125,7 +136,7 @@ class LaravelConsoleTaskTest extends TestCase
         (new LaravelConsoleTaskServiceProvider(null))->boot();
 
         $this->assertTrue(
-            $command->task('Foo', $task)
+            $command->task('Foo', $task, $this->customLoadingMessage)
         );
     }
 
@@ -142,14 +153,14 @@ class LaravelConsoleTaskTest extends TestCase
         $outputMock->expects($this->exactly(3))
             ->method('write')
             ->withConsecutive(
-                [$this->equalTo('Bar: <comment>loading...</comment>')],
+                [$this->equalTo("Bar: <comment>{$this->customLoadingMessage}</comment>")],
                 [$this->equalTo("\x0D")],
                 [$this->equalTo("\x1B[2K")]
             );
 
         $outputMock->expects($this->once())
             ->method('writeln')
-            ->with('Bar: <error>failed</error>');
+            ->with("Bar: <error>{$this->customErrorMessage}</error>");
 
         $commandReflection = new ReflectionClass($command);
 
@@ -164,7 +175,9 @@ class LaravelConsoleTaskTest extends TestCase
                 'Bar',
                 function () {
                     return false;
-                }
+                },
+                $this->customLoadingMessage,
+                $this->customErrorMessage
             )
         );
     }
@@ -181,13 +194,13 @@ class LaravelConsoleTaskTest extends TestCase
 
         $outputMock->expects($this->once())
             ->method('write')
-            ->with('Bar: <comment>loading...</comment>');
+            ->with("Bar: <comment>{$this->customLoadingMessage}</comment>");
 
         $outputMock->expects($this->exactly(2))
             ->method('writeln')
             ->withConsecutive(
                 [''],
-                ['Bar: <error>failed</error>']
+                ["Bar: <error>{$this->customErrorMessage}</error>"]
             );
 
         $commandReflection = new ReflectionClass($command);
@@ -203,7 +216,9 @@ class LaravelConsoleTaskTest extends TestCase
                 'Bar',
                 function () {
                     return false;
-                }
+                },
+                $this->customLoadingMessage,
+                $this->customErrorMessage
             )
         );
     }
@@ -220,13 +235,13 @@ class LaravelConsoleTaskTest extends TestCase
 
         $outputMock->expects($this->once())
             ->method('write')
-            ->with('Bar: <comment>loading...</comment>');
+            ->with("Bar: <comment>{$this->customLoadingMessage}</comment>");
 
         $outputMock->expects($this->exactly(2))
             ->method('writeln')
             ->withConsecutive(
                 [''],
-                ['Bar: <error>failed</error>']
+                ["Bar: <error>{$this->customErrorMessage}</error>"]
             );
 
         $commandReflection = new ReflectionClass($command);
@@ -243,7 +258,9 @@ class LaravelConsoleTaskTest extends TestCase
             'Bar',
             function () {
                 throw new \Exception();
-            }
+            },
+            $this->customLoadingMessage,
+            $this->customErrorMessage
         );
     }
 }

--- a/tests/LaravelConsoleTaskTest.php
+++ b/tests/LaravelConsoleTaskTest.php
@@ -27,12 +27,12 @@ use NunoMaduro\LaravelConsoleTask\LaravelConsoleTaskServiceProvider;
 class LaravelConsoleTaskTest extends TestCase
 {
     /**
-     * Custom task error message
+     * Custom task error message.
      * @var string
      */
     protected $customErrorMessage = 'something went wrong';
     /**
-     * Custom task loading message
+     * Custom task loading message.
      * @var string
      */
     protected $customLoadingMessage = 'doing stuff...';


### PR DESCRIPTION
Let me start by saying this is a great function to add to laravel console commands. This PR adds the ability to customize the error message on failed tasks and adds `@param` blocks to the docblock in the task macro in `LaravelConsoleTaskServiceProvider` for both the new error message param and the loading text param that got merged in a previous PR. I think this is useful to let the executing user know why a task failed other than just saying "failed". This way you can customize the error message provide more detail. As an example:


```php

$file = $this->argument('file');

$this->task("Checking file existence.", function () use ($file){

    if(!file_exists($file)){
        return false;
    }

    return true;

}, "The file [$file] doesnt exist");

```
