### PR TITLE
Allow for custom failed message and custom success messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,17 @@ class LaravelInstallCommand extends Command
             return true;
         });
 
+        $this->task('Analyzing Composer packages', function () {
+            return; // same as `return true;`
+        });
+
         $this->task('Doing something else', function () {
             return false;
         });
+
+        $this->task('Finalizing installation', function () {
+            return 'everything is up and running!';
+        }, 'loading... (this can take a minute or two)', 'oops, something went wrong and needs manual intervention');
     }
 }
 ```

--- a/src/LaravelConsoleTaskServiceProvider.php
+++ b/src/LaravelConsoleTaskServiceProvider.php
@@ -39,14 +39,17 @@ class LaravelConsoleTaskServiceProvider extends ServiceProvider
          */
         Command::macro(
             'task',
-            function (string $title, $task = null, $loadingText = 'loading...') {
+            function (string $title, $task = null, $loadingText = 'loading...', $failedText = 'failed') {
                 $this->output->write("$title: <comment>{$loadingText}</comment>");
 
                 if ($task === null) {
                     $result = true;
                 } else {
                     try {
-                        $result = $task() === false ? false : true;
+                        $result = $task();
+                        if ($result === null) {
+                            $result = true;
+                        }
                     } catch (\Exception $taskException) {
                         $result = false;
                     }
@@ -63,14 +66,14 @@ class LaravelConsoleTaskServiceProvider extends ServiceProvider
                 }
 
                 $this->output->writeln(
-                    "$title: ".($result ? '<info>✔</info>' : '<error>failed</error>')
+                    "$title: ".($result === false ? '<error>'.$failedText.'</error>' : '<info>'.($result === true ? '✔' : $result).'</info>')
                 );
 
                 if (isset($taskException)) {
                     throw $taskException;
                 }
 
-                return $result;
+                return $result !== false;
             }
         );
     }

--- a/src/LaravelConsoleTaskServiceProvider.php
+++ b/src/LaravelConsoleTaskServiceProvider.php
@@ -39,7 +39,7 @@ class LaravelConsoleTaskServiceProvider extends ServiceProvider
          */
         Command::macro(
             'task',
-            function (string $title, $task = null, $loadingText = 'loading...', $failedText = 'failed') {
+            function (string $title, $task = null, $loadingText = 'loading...', $failureText = 'failed') {
                 $this->output->write("$title: <comment>{$loadingText}</comment>");
 
                 if ($task === null) {
@@ -66,7 +66,7 @@ class LaravelConsoleTaskServiceProvider extends ServiceProvider
                 }
 
                 $this->output->writeln(
-                    "$title: ".($result === false ? '<error>'.$failedText.'</error>' : '<info>'.($result === true ? '✔' : $result).'</info>')
+                    "$title: ".($result === false ? '<error>'.$failureText.'</error>' : '<info>'.($result === true ? '✔' : $result).'</info>')
                 );
 
                 if (isset($taskException)) {


### PR DESCRIPTION
As discussed in #10, this PR adds support for custom success messages of tasks. As there is no way to distinguish between success and failure other than checking the result for `false`, I decided to add a fourth parameter to the macro which allows to set a custom failure message. This message simply allows to customize the currently hardcoded `failed` response:

```php
class SomeCommand extends Command
{
    public function handle()
    {
        $this->task('Finalizing installation', function () {
            return 'everything is up and running!';
        }, 'loading... (this can take a minute or two)', 'oops, something went wrong and needs manual intervention');
    }
}

/* OUTPUT (same line if decorated output is supported) */
// Finalizing installation: <comment>loading... (this can take a minute or two)</comment>
// Finalizing installation: <info>everything is up and running!</info>
// Finalizing installation: <error>oops, something went wrong and needs manual intervention</error>
```

In theory, this PR is not backwards compatible, as it changes the output for `return 'OK';` compared to the previous version (not the return value of `$this->task()` though). But as the special scenarios without a return value or something different to a boolean have never been documented, I guess it would still be fine to release it as minor version or so...