### PR TITLE
Support additional task output

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ composer require nunomaduro/laravel-console-task
 ## Usage
 
 ```php
+use NunoMaduro\LaravelConsoleTask\ConsoleTaskOutput;
+
 class LaravelInstallCommand extends Command
 {
     /**
@@ -42,6 +44,25 @@ class LaravelInstallCommand extends Command
 
         $this->task('Doing something else', function () {
             return false;
+        });
+
+        $this->task('Finalizing installation', function (ConsoleTaskOutput $output) {
+            // [optional]
+            // $output->setIndentation('  --> ');
+            
+            $output->text('Collecting important data...');
+            $output->note('Fetching news feeds...');
+            $output->comment('Evaluating requirements...');
+
+            $output->caution('No existing users found.');
+
+            if ($this->requiresUser()) {
+                $output->error('A user is required to use the application.');
+                return false;
+            }
+
+            $output->success('All up and running!');
+            return true;
         });
     }
 }

--- a/src/ConsoleTaskOutput.php
+++ b/src/ConsoleTaskOutput.php
@@ -18,8 +18,6 @@ use Illuminate\Console\OutputStyle;
 /**
  * An output proxy for console tasks. Allows tasks to print additional
  * output during execution.
- * 
- * @package NunoMaduro\LaravelConsoleTask
  */
 class ConsoleTaskOutput
 {
@@ -40,13 +38,13 @@ class ConsoleTaskOutput
      */
     public function __construct(OutputStyle $output, string $indentation = '  -> ')
     {
-        $this->output      = $output;
+        $this->output = $output;
         $this->indentation = $indentation;
     }
 
     /**
      * Sets the indentation used for additional task output.
-     * 
+     *
      * @param string $indentation
      * @return void
      */

--- a/src/ConsoleTaskOutput.php
+++ b/src/ConsoleTaskOutput.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Laravel Console Task.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\LaravelConsoleTask;
+
+use Illuminate\Console\OutputStyle;
+
+/**
+ * An output proxy for console tasks. Allows tasks to print additional
+ * output during execution.
+ * 
+ * @package NunoMaduro\LaravelConsoleTask
+ */
+class ConsoleTaskOutput
+{
+    /** @var OutputStyle */
+    protected $output;
+
+    /** @var string */
+    protected $indentation;
+
+    /** @var int */
+    protected $writes = 0;
+
+    /**
+     * ConsoleTaskOutput constructor.
+     *
+     * @param OutputStyle $output
+     * @param string      $indentation
+     */
+    public function __construct(OutputStyle $output, string $indentation = '  -> ')
+    {
+        $this->output      = $output;
+        $this->indentation = $indentation;
+    }
+
+    /**
+     * Sets the indentation used for additional task output.
+     * 
+     * @param string $indentation
+     * @return void
+     */
+    public function setIndentation(string $indendation): void
+    {
+        $this->indentation = $indendation;
+    }
+
+    /**
+     * Writes a normal text line to the output.
+     *
+     * @param string $text
+     * @return void
+     */
+    public function text(string $text): void
+    {
+        $this->writeln($text, '');
+    }
+
+    /**
+     * Writes a success message to the output.
+     *
+     * @param string $text
+     * @return void
+     */
+    public function success(string $text): void
+    {
+        $this->writeln($text, '<info>');
+    }
+
+    /**
+     * Writes an error message to the output.
+     *
+     * @param string $text
+     * @return void
+     */
+    public function error(string $text): void
+    {
+        $this->writeln($text, '<error>');
+    }
+
+    /**
+     * Writes a caution warning to the output.
+     *
+     * @param string $text
+     * @return void
+     */
+    public function caution(string $text): void
+    {
+        $this->writeln($text, '<fg=blue>');
+    }
+
+    /**
+     * Writes a comment to the output.
+     *
+     * @param string $text
+     * @return void
+     */
+    public function comment(string $text): void
+    {
+        $this->writeln($text, '<comment>');
+    }
+
+    /**
+     * Writes a note to the output.
+     *
+     * @param string $text
+     * @return void
+     */
+    public function note(string $text): void
+    {
+        $this->writeln($text, '<fg=magenta>');
+    }
+
+    /**
+     * Returns whether this proxy has written to the output.
+     *
+     * @return bool
+     */
+    public function hasCreatedOutput(): bool
+    {
+        return $this->writes > 0;
+    }
+
+    /**
+     * Returns the number of written lines.
+     *
+     * @return int
+     */
+    public function countWrittenLines(): int
+    {
+        return $this->writes;
+    }
+
+    /**
+     * Writes a string to the output with a given format.
+     *
+     * @param string $text
+     * @param string $format
+     * @return void
+     */
+    protected function writeln(string $text, string $format): void
+    {
+        if ($this->writes === 0) {
+            $this->output->newLine();
+        }
+
+        $this->output->writeln(sprintf('%s%s%s</>', $this->indentation, $format, $text));
+
+        $this->writes++;
+    }
+}

--- a/src/LaravelConsoleTaskServiceProvider.php
+++ b/src/LaravelConsoleTaskServiceProvider.php
@@ -60,10 +60,10 @@ class LaravelConsoleTaskServiceProvider extends ServiceProvider
                     $this->output->write("\x1B[s");         // Save current cursor position
                     $this->output->write("\x1B[{$lines}A"); // Move cursor $lines rows up
                     $this->output->write("\x1B[2K");        // Erase the line
-                } else if ($this->output->isDecorated()) {
+                } elseif ($this->output->isDecorated()) {
                     $this->output->write("\x0D");           // Move the cursor to the beginning of the line
                     $this->output->write("\x1B[2K");        // Erase the line
-                } else if (!$this->output->isDecorated() && !$taskOutput->hasCreatedOutput()) {
+                } elseif (! $this->output->isDecorated() && ! $taskOutput->hasCreatedOutput()) {
                     $this->output->writeln('');             // Make sure we first close the previous line
                 }
 

--- a/tests/LaravelConsoleTaskTest.php
+++ b/tests/LaravelConsoleTaskTest.php
@@ -16,7 +16,7 @@ namespace NunoMaduro\Tests\LaravelConsoleTask;
 use ReflectionClass;
 use Illuminate\Console\Command;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Output\OutputInterface;
+use Illuminate\Console\OutputStyle;
 use NunoMaduro\LaravelConsoleTask\LaravelConsoleTaskServiceProvider;
 
 /**
@@ -47,9 +47,9 @@ class LaravelConsoleTaskTest extends TestCase
     {
         $command = new Command();
 
-        $outputMock = $this->createMock(OutputInterface::class);
+        $outputMock = $this->createMock(OutputStyle::class);
 
-        $outputMock->expects($this->once())
+        $outputMock->expects($this->atLeastOnce())
             ->method('isDecorated')
             ->willReturn(true);
 
@@ -78,6 +78,61 @@ class LaravelConsoleTaskTest extends TestCase
         );
     }
 
+    public function testSuccessfulTaskWithAdditionalDecoratedOutput()
+    {
+        $command = new Command();
+
+        $outputMock = $this->createMock(OutputStyle::class);
+
+        $outputMock->expects($this->atLeastOnce())
+            ->method('isDecorated')
+            ->willReturn(true);
+
+        $outputMock->expects($this->exactly(5))
+            ->method('write')
+            ->withConsecutive(
+                [$this->equalTo('Foo: <comment>loading...</comment>')],
+                [$this->equalTo("\x1B[s")],
+                [$this->equalTo("\x1B[7A")],
+                [$this->equalTo("\x1B[2K")],
+                [$this->equalTo("\x1B[u")]
+            );
+
+        $outputMock->expects($this->once())
+            ->method('newLine');
+
+        $outputMock->expects($this->exactly(7))
+            ->method('writeln')
+            ->withConsecutive(
+                ['  -> Foo</>'],
+                ['  -> <info>Bar</>'],
+                ['  -> <error>Baz</>'],
+                ['  -> <fg=magenta>Fizz</>'],
+                ['  -> <fg=blue>Buzz</>'],
+                ['  -> <comment>Lightning</>'],
+                ['Foo: <info>✔</info>']
+            );
+
+        $commandReflection = new ReflectionClass($command);
+
+        $commandOutputProperty = $commandReflection->getProperty('output');
+        $commandOutputProperty->setAccessible(true);
+        $commandOutputProperty->setValue($command, $outputMock);
+
+        (new LaravelConsoleTaskServiceProvider(null))->boot();
+
+        $this->assertTrue(
+            $command->task('Foo', function ($output) {
+                $output->text('Foo');
+                $output->success('Bar');
+                $output->error('Baz');
+                $output->note('Fizz');
+                $output->caution('Buzz');
+                $output->comment('Lightning');
+            })
+        );
+    }
+
     public function testSuccessfulTaskWithReturnValueAndWithoutDecoratedOutput()
     {
         $this->performTestSuccessfulTaskWithoutDecoratedOutput(
@@ -99,9 +154,9 @@ class LaravelConsoleTaskTest extends TestCase
     {
         $command = new Command();
 
-        $outputMock = $this->createMock(OutputInterface::class);
+        $outputMock = $this->createMock(OutputStyle::class);
 
-        $outputMock->expects($this->once())
+        $outputMock->expects($this->atLeastOnce())
             ->method('isDecorated')
             ->willReturn(false);
 
@@ -129,13 +184,62 @@ class LaravelConsoleTaskTest extends TestCase
         );
     }
 
+    public function testSuccessfulTaskWithAdditionalOutputButWithoutDecoratedOutput()
+    {
+        $command = new Command();
+
+        $outputMock = $this->createMock(OutputStyle::class);
+
+        $outputMock->expects($this->atLeastOnce())
+            ->method('isDecorated')
+            ->willReturn(false);
+
+        $outputMock->expects($this->once())
+            ->method('write')
+            ->with('Foo: <comment>loading...</comment>');
+
+            $outputMock->expects($this->once())
+                ->method('newLine');
+    
+            $outputMock->expects($this->exactly(7))
+                ->method('writeln')
+                ->withConsecutive(
+                    ['  -> Foo</>'],
+                    ['  -> <info>Bar</>'],
+                    ['  -> <error>Baz</>'],
+                    ['  -> <fg=magenta>Fizz</>'],
+                    ['  -> <fg=blue>Buzz</>'],
+                    ['  -> <comment>Lightning</>'],
+                    ['Foo: <info>✔</info>']
+                );
+
+        $commandReflection = new ReflectionClass($command);
+
+        $commandOutputProperty = $commandReflection->getProperty('output');
+        $commandOutputProperty->setAccessible(true);
+        $commandOutputProperty->setValue($command, $outputMock);
+
+        (new LaravelConsoleTaskServiceProvider(null))->boot();
+
+        $this->assertTrue(
+            $command->task('Foo', function ($output) {
+                $output->text('Foo');
+                $output->success('Bar');
+                $output->error('Baz');
+                $output->note('Fizz');
+                $output->caution('Buzz');
+                $output->comment('Lightning');
+            })
+        );
+    }
+
     public function testUnsuccessfulTaskWithDecoratedOutput()
     {
         $command = new Command();
 
-        $outputMock = $this->createMock(OutputInterface::class);
+        $outputMock = $this->createMock(OutputStyle::class);
 
-        $outputMock->expects($this->once())
+        $outputMock->expects($this->atLeastOnce())
             ->method('isDecorated')
             ->willReturn(true);
 
@@ -173,9 +277,9 @@ class LaravelConsoleTaskTest extends TestCase
     {
         $command = new Command();
 
-        $outputMock = $this->createMock(OutputInterface::class);
+        $outputMock = $this->createMock(OutputStyle::class);
 
-        $outputMock->expects($this->once())
+        $outputMock->expects($this->atLeastOnce())
             ->method('isDecorated')
             ->willReturn(false);
 
@@ -212,9 +316,9 @@ class LaravelConsoleTaskTest extends TestCase
     {
         $command = new Command();
 
-        $outputMock = $this->createMock(OutputInterface::class);
+        $outputMock = $this->createMock(OutputStyle::class);
 
-        $outputMock->expects($this->once())
+        $outputMock->expects($this->atLeastOnce())
             ->method('isDecorated')
             ->willReturn(false);
 

--- a/tests/LaravelConsoleTaskTest.php
+++ b/tests/LaravelConsoleTaskTest.php
@@ -198,20 +198,20 @@ class LaravelConsoleTaskTest extends TestCase
             ->method('write')
             ->with('Foo: <comment>loading...</comment>');
 
-            $outputMock->expects($this->once())
-                ->method('newLine');
-    
-            $outputMock->expects($this->exactly(7))
-                ->method('writeln')
-                ->withConsecutive(
-                    ['  -> Foo</>'],
-                    ['  -> <info>Bar</>'],
-                    ['  -> <error>Baz</>'],
-                    ['  -> <fg=magenta>Fizz</>'],
-                    ['  -> <fg=blue>Buzz</>'],
-                    ['  -> <comment>Lightning</>'],
-                    ['Foo: <info>✔</info>']
-                );
+        $outputMock->expects($this->once())
+            ->method('newLine');
+
+        $outputMock->expects($this->exactly(7))
+            ->method('writeln')
+            ->withConsecutive(
+                ['  -> Foo</>'],
+                ['  -> <info>Bar</>'],
+                ['  -> <error>Baz</>'],
+                ['  -> <fg=magenta>Fizz</>'],
+                ['  -> <fg=blue>Buzz</>'],
+                ['  -> <comment>Lightning</>'],
+                ['Foo: <info>✔</info>']
+            );
 
         $commandReflection = new ReflectionClass($command);
 


### PR DESCRIPTION
As noted in #10, this PR adds support for additional task output. This is done by passing an instance of the new `ConsoleTaskOutput` class to the task closure. This class offers some of the output methods the `Symfony\Component\Console\Output\OutputInterface` also offers. All additional output is prefixed with an indentation string, which is customizable through a setter method.

When tasks are run in a console supporting decorated output, the task line containing the `loading...` string will be replaced using escape sequences (similar to what we had so far). To achieve this, the cursor location will be saved, then the cursor will be moved the number of additionally written lines up and the line will be erased. After rewriting the line with the final status, the cursor location will be restored. This will also work with #11 together nicely.

A quick demo showcasing the example of the readme:
![render1568053088097](https://user-images.githubusercontent.com/8877609/64556106-0f069200-d33f-11e9-94a3-b4d60d04156d.gif)

In theory, this is completely backwards compatible. Nevertheless, I would appreciate if some people try this out before it gets merged.