### PR TITLE
Add tests folder to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@
 /CHANGELOG.md       export-ignore
 /CONTRIBUTING.md    export-ignore
 /docs               export-ignore
+/tests              export-ignore


### PR DESCRIPTION
Add the tests folder to `.gitattributes` with `export-ignore` flag set, so they're not pulled down as part of a project's dependencies via composer.