### PR TITLE
chore(deps): update to require Laravel 9 or later

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        php: ['7.3', '7.4', '8.0', '8.1']
+        php: ['8.1', '8.2']
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Laravel Console Task was created by, and is maintained by [Nuno Maduro](https://
 ## Installation
 
 > **Requires:**
-> - **[PHP 7.2.5+](https://php.net/releases/)**
-> - **[Laravel 6.0+](https://github.com/laravel/laravel)**
+> - **[PHP 8.1+](https://php.net/releases)**
+> - **[Laravel 9.0+](https://github.com/laravel/laravel)**
 
 Require Laravel Console Task using [Composer](https://getcomposer.org):
 

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
         }
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
-        "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0"
+        "php": "^8.1",
+        "illuminate/console": "^9.0|^10.0",
+        "illuminate/support": "^9.0|^10.0"
     },
     "require-dev": {
-        "pestphp/pest": "^1.20"
+        "pestphp/pest": "^1.22.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This updates to require Laravel 9 or later, and PHP 8.1 or later.