### PR TITLE
feat: add Laravel 11.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/support": "^9.0|^10.0|^11.0"
     },
     "require-dev": {
-        "pestphp/pest": "^1.22.3"
+        "pestphp/pest": "^1.22.3|^2.34"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,15 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/console": "^9.0|^10.0",
-        "illuminate/support": "^9.0|^10.0"
+        "illuminate/console": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "pestphp/pest": "^1.22.3"
     },
     "autoload": {
         "psr-4": {
+            "NunoMaduro\\Tests\\LaravelConsoleTask\\": "tests/",
             "NunoMaduro\\LaravelConsoleTask\\": "src/"
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,20 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/console": "^9.0|^10.0|^11.0",
-        "illuminate/support": "^9.0|^10.0|^11.0"
+        "illuminate/console": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0"
     },
     "require-dev": {
-        "pestphp/pest": "^1.22.3|^2.34"
+        "pestphp/pest": "^2.34"
     },
     "autoload": {
         "psr-4": {
-            "NunoMaduro\\Tests\\LaravelConsoleTask\\": "tests/",
             "NunoMaduro\\LaravelConsoleTask\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "NunoMaduro\\Tests\\LaravelConsoleTask\\": "tests/"
         }
     },
     "config": {

--- a/tests/LaravelConsoleTaskTest.php
+++ b/tests/LaravelConsoleTaskTest.php
@@ -15,6 +15,7 @@ namespace NunoMaduro\Tests\LaravelConsoleTask;
 
 use Illuminate\Console\Command;
 use NunoMaduro\LaravelConsoleTask\LaravelConsoleTaskServiceProvider;
+use NunoMaduro\Tests\LaravelConsoleTask\WithConsecutive;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -55,10 +56,11 @@ class LaravelConsoleTaskTest extends TestCase
 
         $outputMock->expects($this->exactly(3))
             ->method('write')
-            ->withConsecutive(
+            ->with(...WithConsecutive::create(
                 [$this->equalTo('Foo: <comment>loading...</comment>')],
                 [$this->equalTo("\x0D")],
                 [$this->equalTo("\x1B[2K")]
+            )
             );
 
         $outputMock->expects($this->once())
@@ -111,9 +113,10 @@ class LaravelConsoleTaskTest extends TestCase
 
         $outputMock->expects($this->exactly(2))
             ->method('writeln')
-            ->withConsecutive(
+            ->with(...WithConsecutive::create(
                 [''],
                 ['Foo: <info>✔</info>']
+            )
             );
 
         $commandReflection = new ReflectionClass($command);
@@ -141,10 +144,11 @@ class LaravelConsoleTaskTest extends TestCase
 
         $outputMock->expects($this->exactly(3))
             ->method('write')
-            ->withConsecutive(
+            ->with(...WithConsecutive::create(
                 [$this->equalTo('Bar: <comment>loading...</comment>')],
                 [$this->equalTo("\x0D")],
                 [$this->equalTo("\x1B[2K")]
+            )
             );
 
         $outputMock->expects($this->once())
@@ -185,9 +189,10 @@ class LaravelConsoleTaskTest extends TestCase
 
         $outputMock->expects($this->exactly(2))
             ->method('writeln')
-            ->withConsecutive(
+            ->with(...WithConsecutive::create(
                 [''],
                 ['Bar: <error>failed</error>']
+            )
             );
 
         $commandReflection = new ReflectionClass($command);
@@ -224,9 +229,10 @@ class LaravelConsoleTaskTest extends TestCase
 
         $outputMock->expects($this->exactly(2))
             ->method('writeln')
-            ->withConsecutive(
+            ->with(...WithConsecutive::create(
                 [''],
                 ['Bar: <error>failed</error>']
+            )
             );
 
         $commandReflection = new ReflectionClass($command);

--- a/tests/LaravelConsoleTaskTest.php
+++ b/tests/LaravelConsoleTaskTest.php
@@ -15,7 +15,6 @@ namespace NunoMaduro\Tests\LaravelConsoleTask;
 
 use Illuminate\Console\Command;
 use NunoMaduro\LaravelConsoleTask\LaravelConsoleTaskServiceProvider;
-use NunoMaduro\Tests\LaravelConsoleTask\WithConsecutive;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/tests/WithConsecutive.php
+++ b/tests/WithConsecutive.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
-Usage: ->with(...WithConsecutive::create(...$withCodes))
+ * Usage: ->with(...WithConsecutive::create(...$withCodes)).
  */
 
 declare(strict_types=1);
@@ -17,8 +17,7 @@ use RuntimeException;
 class WithConsecutive
 {
     /**
-     * @param array<mixed> $parameterGroups
-     *
+     * @param  array<mixed>  $parameterGroups
      * @return array<int, Callback<mixed>>
      */
     public static function create(...$parameterGroups): array
@@ -39,7 +38,7 @@ class WithConsecutive
 
             // prepare parameters
             foreach ($parameters as $parameter) {
-                if (!$parameter instanceof Constraint) {
+                if (! $parameter instanceof Constraint) {
                     $parameter = new IsEqual($parameter);
                 }
 
@@ -55,7 +54,7 @@ class WithConsecutive
         }
 
         // build callback
-        for ($index = 0; $index < $parametersCount; ++$index) {
+        for ($index = 0; $index < $parametersCount; $index++) {
             $result[$index] = Assert::callback(static function ($value) use ($values, $index) {
                 static $map = null;
                 $map ??= $values[$index];

--- a/tests/WithConsecutive.php
+++ b/tests/WithConsecutive.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+Usage: ->with(...WithConsecutive::create(...$withCodes))
+ */
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Tests\LaravelConsoleTask;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Constraint\Callback;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Constraint\IsEqual;
+use RuntimeException;
+
+class WithConsecutive
+{
+    /**
+     * @param array<mixed> $parameterGroups
+     *
+     * @return array<int, Callback<mixed>>
+     */
+    public static function create(...$parameterGroups): array
+    {
+        $result = [];
+        $parametersCount = null;
+        $groups = [];
+        $values = [];
+
+        foreach ($parameterGroups as $index => $parameters) {
+            // initial
+            $parametersCount ??= count($parameters);
+
+            // compare
+            if ($parametersCount !== count($parameters)) {
+                throw new RuntimeException('Parameters count max much in all groups');
+            }
+
+            // prepare parameters
+            foreach ($parameters as $parameter) {
+                if (!$parameter instanceof Constraint) {
+                    $parameter = new IsEqual($parameter);
+                }
+
+                $groups[$index][] = $parameter;
+            }
+        }
+
+        // collect values
+        foreach ($groups as $parameters) {
+            foreach ($parameters as $index => $parameter) {
+                $values[$index][] = $parameter;
+            }
+        }
+
+        // build callback
+        for ($index = 0; $index < $parametersCount; ++$index) {
+            $result[$index] = Assert::callback(static function ($value) use ($values, $index) {
+                static $map = null;
+                $map ??= $values[$index];
+
+                $expectedArg = array_shift($map);
+                if ($expectedArg === null) {
+                    throw new RuntimeException('No more expected calls');
+                }
+                $expectedArg->evaluate($value);
+
+                return true;
+            });
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
Upgrades to dependencies for Laravel 11.x

Main upgrade is to the tests which needed another library to replace testing the feature withConsecutive from PHPUnit that was removed in version 10.